### PR TITLE
Add coinbase api models for the websocket channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# vwap-engine
+# VWAP Engine
+
+**[VWAP](https://en.wikipedia.org/wiki/Volume-weighted_average_price) Calculator for Go.**
+
+![](https://img.shields.io/github/license/reactivejson/vwap-engine.svg)
+
+Go implementation of VWAP formula, vwap is calculated in real time utilizing
+the Coinbase websocket stream "wss://ws-feed.pro.coinbase.com". For each trading pair, the calculated VWAP will be logged to Stdout.
+The default trading pairs are BTC-USD, ETH-USD, and ETH-BTC, but you can define your owns via ENV variables
+
+## License
+
+Apache 2.0, see [LICENSE](LICENSE).

--- a/api/models/coinbase.go
+++ b/api/models/coinbase.go
@@ -1,0 +1,44 @@
+package models
+
+/**
+ * @author Mohamed-Aly Bou-Hanane
+ * © 2022
+ */
+
+// Channel is a Model to subscribe to the Coinbase Websocket stream channels
+type Channel struct {
+	Name       string   `json:"name"`
+	ProductIDs []string `json:"product_ids" mapstructure:"product_ids"`
+}
+
+// CoinbaseRequest JSON Payload request to be sent to subscribe to the Coinbase Websocket stream channels
+/**
+Sample:
+{
+    "type": "subscribe",
+    "product_ids": [
+        "ETH-USD",
+        "BTC-USD"
+    ],
+    "channels": ["ticker_batch"]
+}
+*/
+type CoinbaseRequest struct {
+	Type       string    `json:"type"`
+	ProductIDs []string  `json:"product_ids"`
+	Channels   []Channel `json:"channels"`
+}
+
+// CoinbaseResponse is the coinbase response payload.
+type CoinbaseResponse struct {
+	Channels []Channel `json:"channels"`
+	Message  string    `json:"message,omitempty"`
+	Price    string    `json:"price"`
+	//ProductID  is the coinbase for TradingPair
+	ProductID string `json:"product_id"`
+	Size      string `json:"size"`
+	Type      string `json:"type"`
+	Time      string `json:"time"`
+	TradeID   int    `json:"trade_id"`
+	Side      string `json:"side"`
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/reactivejson/vwap-engine
+
+go 1.18


### PR DESCRIPTION
Map coinbase JSON to a Go structs

- Channel is a Model to subscribe to the Coinbase Websocket stream
channels
- CoinbaseResponse is the coinbase response payload.
- CoinbaseRequest: JSON Payload request to be sent to subscribe to the
Coinbase Websocket stream channels