### PR TITLE
Usage of data structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,9 @@ Every time a new data point is added to the queue and saved for each trading pai
 For performance, and to avoid exponential complexity, the computation is cached for VWAP, CumulativeQuantity,
 and CumulativePriceQuantity for existing data points and updated with new entries.
 
-Two implementations available:
+Two implementations:
 1) Doubly linked-list queue: Manipulation with LinkedList is faster than ArrayList because it uses a doubly linked list, so no bit shifting is required in memory.
 2) Array-backed queue: Manipulation with ArrayList is slow because it internally uses an array. If any element is removed from the array, all the other elements are shifted in memory.
-
 
 ### Main
 The core entry point into the app. will setup the config,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,9 +41,11 @@ func main() {
 	//The arrays allocated in memory are never returned. Therefor A dynamic doubly Linked list structure, is better to be used for a long-living queue.
 	if cfg.WindowSize < 500 {
 		// Array backed queue
+		// Manipulation with ArrayList is slow because it internally uses an array. If any element is removed from the array, all the other elements are shifted in memory.
 		queue, err = queue2.NewVwapQueue(cfg.WindowSize)
 	} else {
 		// doubly linked-list queue
+		// Manipulation with LinkedList is faster than ArrayList because it uses a doubly linked list, so no bit shifting is required in memory.
 		queue, err = linked_list.NewVwapLinkedList(cfg.WindowSize)
 	}
 	if err != nil {

--- a/internal/storage/linked-list/vwap-linked-list.go
+++ b/internal/storage/linked-list/vwap-linked-list.go
@@ -8,6 +8,7 @@ import (
 )
 
 // vwapLinkedList represents a doubly linked list as a queue of DataPoints.
+// Manipulation with Linked List is faster than Array List because it uses a doubly linked list, so no bit shifting is required in memory.
 //Every time a new data point is added to the queue and saved for each trading pair, the VWAP computation is updated accordingly.
 // For performance, and to avoid exponential complexity, the computation is cached for VWAP, CumulativeQuantity,
 //and CumulativePriceQuantity for existing data points and updated with new entries.

--- a/internal/storage/queue/vwap-queue.go
+++ b/internal/storage/queue/vwap-queue.go
@@ -6,6 +6,7 @@ import (
 )
 
 // VwapQueue represents a queue of DataPoints.
+// Manipulation with ArrayList is slow because it internally uses an array. If any element is removed from the array, all the other elements are shifted in memory.
 //Every time a new data point is added to the queue and saved for each trading pair, the VWAP computation is updated accordingly.
 // For performance, and to avoid exponential complexity, the computation is cached for VWAP, CumulativeQuantity,
 //and CumulativePriceQuantity for existing data points and updated with new entries.


### PR DESCRIPTION
Manipulation with ArrayList is slow because it internally uses an array.
If any element is removed from the array, all the other elements are
shifted in memory.

Manipulation with LinkedList is faster than ArrayList because it uses a
doubly linked list, so no bit shifting is required in memory.